### PR TITLE
the 'initial' tag is missing the :main namespace specification

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,3 +1,4 @@
 (defproject blorg "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.4.0"]
-                 [noir "1.3.0-beta7"]])
+                 [noir "1.3.0-beta7"]]
+  :main blorg.core)


### PR DESCRIPTION
Problem:
         No :main namespace specified in project.clj.
Solution:
         add the :main namespace
